### PR TITLE
rate limit application-level workaround

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ Werkzeug==3.1.3
 pytest
 coverage
 Flask-WTF
+Flask-Limiter>=3.10.1


### PR DESCRIPTION
Since it is not possible setup load balancers in Free tier GC, therefore can't use Cloud Armor policies. 
This workaround won't prevent the excessive requests from reaching the Cloud Run instance, but at least the processing would be lower and will preventing resource overload to some degree...